### PR TITLE
replace language into generatorName for 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
                         </goals>
                         <configuration>
                             <inputSpec>${project.basedir}/src/main/resources/api.json</inputSpec>
-                            <language>kotlin</language>
+                            <generatorName>kotlin</generatorName>
                             <configOptions>
                                 <sourceFolder>src/gen/java/main</sourceFolder>
                             </configOptions>


### PR DESCRIPTION
openapi-generator-maven-plugin 5.1.0 requires generatorName.
language is deprecated.